### PR TITLE
package metadata fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,14 @@ All issues about Mockup_ related projects are tracked at:
 https://github.com/plone/mockup/issues
 
 
+Credits
+=======
+
+Originally created by `Rok Garbas <http://garbas.si/>`_ using parts of `Patterns
+library <http://patternslib.com/>`_. Now maintained by the `Plone Foundation
+<http://plone.org/>`_.
+
+
 Status of builds
 ================
 

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "mockup-core",
-  "version": "1.2.11",
-  "description": "Mockup Core",
+  "description": "Core library for the Mockup front end library",
   "dependencies": {
     "backbone": "1.1.2",
     "bootstrap": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mockup-core",
-  "version": "1.2.11",
-  "description": "Plone CMS Mockup Core",
+  "version": "1.2.11-dev",
+  "description": "Core library for the Mockup front end library",
   "homepage": "http://plone.github.io/mockup",
   "devDependencies": {
     "bower": "~1.3.1",
@@ -34,9 +34,9 @@
   },
   "maintainers": [
     {
-      "name": "Rok Garbas",
-      "email": "rok@garbas.si",
-      "url": "http://garbas.si"
+      "name": "Plone Foundation",
+      "email": "plone-developers@lists.sourceforge.net",
+      "url": "http://plone.org"
     }
   ],
   "repository": {
@@ -45,7 +45,7 @@
   },
   "bugs": {
     "url": "https://github.com/plone/mockup/issues",
-    "email": "rok@garbas.si"
+    "email": "plone-developers@lists.sourceforge.net",
   },
   "licenses": [
     {


### PR DESCRIPTION
Like https://github.com/plone/mockup/pull/420
- Remove version specifier from bower.json. Bower discourages to use it: https://github.com/bower/bower.json-spec#version - Bower only uses the git tag.
- Change package maintainer info from Rok Garbas to Plone Foundation.
