### PR TITLE
trigger 'scan_finished.registry.mockup-core' event

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,11 @@ Changelog
 v1.2.14 - unreleased
 --------------------
 
-- Nothing changed yet.
+- Trigger the event 'scan-completed.registry.mockup-core' on document after the
+  DOM pattern scan was completed and all patterns were initialized. This way,
+  we can register event subscribers, which rely on the DOM manipulations by
+  other patterns.
+  [thet]
 
 
 v1.2.13 - 2014-10-28

--- a/js/registry.js
+++ b/js/registry.js
@@ -91,6 +91,9 @@ define([
           }
         });
       });
+      // Trigger event after pattern scan has completed and all patterns were
+      // initialized
+      $(document).trigger('scan-completed.registry.mockup-core');
     },
 
     register: function(Pattern) {

--- a/tests/registry-test.js
+++ b/tests/registry-test.js
@@ -2,9 +2,10 @@
 
 define([
   'expect',
+  'sinon',
   'jquery',
   'mockup-registry'
-], function(expect, $, Registry) {
+], function(expect, sinon, $, Registry) {
   'use strict';
 
   window.mocha.setup('bdd');
@@ -100,6 +101,15 @@ define([
       };
       Registry.scan($el);
       expect($el.data('pattern-example').example).to.be.equal('works');
+    });
+
+    it('trigger event on completed scan', function () {
+      var spy = sinon.spy();
+      // register spy as event listener
+      $(document).on('scan-completed.registry.mockup-core', spy);
+      var $el = $('<div />');
+      Registry.scan($el);
+      expect(spy.called).to.be(true);  // spy must be called
     });
 
     it('try register a pattern without name', function() {


### PR DESCRIPTION
Trigger the event 'scan-completed.registry.mockup-core' on document after the DOM pattern scan was completed and all patterns were initialized. This way, we can register event subscribers, which rely on the DOM manipulations by other patterns. (EDITED)
