### PR TITLE
Add karma config to run tests on Jenkins

### DIFF
--- a/js/grunt.js
+++ b/js/grunt.js
@@ -320,6 +320,7 @@
       }
       grunt.registerTask('test', [ 'jshint', 'karma:test' ]);
       grunt.registerTask('test_once', [ 'jshint', 'karma:testOnce' ]);
+      grunt.registerTask('test_jenkins', [ 'jshint', 'karma:testJenkins' ]);
       grunt.registerTask('test_dev', [ 'karma:testDev' ]);
       grunt.registerTask('test_serve', [ 'karma:testServe' ]);
       grunt.registerTask('test_ci', [ 'jshint', 'karma:testCI'].concat(bundles));
@@ -363,6 +364,16 @@
           testOnce: {
             singleRun: true,
             browsers: ['PhantomJS']
+          },
+          testJenkins: {
+            autoWatch: false,
+            colors: false,
+            singleRun: true,
+            browsers: ['PhantomJS'],
+            reporters: ['junit'],
+            junitReporter: {
+              outputFile: 'test-results.xml'
+            },
           },
           testDev: {
             browsers: ['Chrome'],


### PR DESCRIPTION
Add another karma configuration to save tests results on an xml
file that can be used by Jenkins publishers.

This is needed as part of https://github.com/plone/jenkins.plone.org/issues/108

Another pull request on mockup to use this karma config is on the way as well.